### PR TITLE
Set order of service post excerpt

### DIFF
--- a/bin/streaming-utilities
+++ b/bin/streaming-utilities
@@ -504,6 +504,7 @@ def sync_with_wordpress(update):
                     "physical": True,
                     "show_bcp_reproduction_notice": show_bcp_reproduction_notice,
                 },
+                "excerpt": service_object.description,
             }
 
             if service_object.youtube_id:


### PR DESCRIPTION
The excerpt will be used in OpenGraph and Twitter card descriptions, which gives a more useful summary if anyone shares this order of service.