### PR TITLE
Move call for service slug to only happen if public

### DIFF
--- a/bin/streaming-utilities
+++ b/bin/streaming-utilities
@@ -345,25 +345,13 @@ def sync_with_youtube(update):
 
         # Build up the description
 
-        order_of_service_url = "https://whitkirkchurch.org.uk/oos/{slug}".format(
-            slug=service_object.slug
-        )
-
-        youtube_description = (
-            service_object.description
-            + "\r\n\r\n"
-            + "View the order of service online at {oos_url}".format(
-                oos_url=order_of_service_url
-            )
-        )
-
         if service_object.is_stream_public:
             youtube_privacy = "public"
             youtube_description = (
                 service_object.description
                 + "\r\n\r\n"
-                + "View the order of service online at {oos_url}".format(
-                    oos_url=order_of_service_url
+                + "View the order of service online at https://whitkirkchurch.org.uk/oos/{slug}".format(
+                    slug=service_object.slug
                 )
             )
         else:


### PR DESCRIPTION
Private streams don't have visible slugs, so this was tripping over cases where it was trying to generate an (ultimately unused) order of service URL for a private stream.