### PR TITLE
Add privacy declarations back to LiveStream object

### DIFF
--- a/bin/service/__init__.py
+++ b/bin/service/__init__.py
@@ -294,3 +294,10 @@ class Service:
             return True
         else:
             return False
+
+    @property
+    def youtube_privacy(self):
+        if self.is_stream_public:
+            return "public"
+        else:
+            return "unlisted"

--- a/bin/streaming-utilities
+++ b/bin/streaming-utilities
@@ -334,11 +334,6 @@ def sync_with_youtube(update):
 
         # Set the privacy
 
-        if service_object.is_stream_public:
-            youtube_privacy = "public"
-        else:
-            youtube_privacy = "unlisted"
-
         # Build up the description
 
         if service_object.has_oos:
@@ -359,6 +354,9 @@ def sync_with_youtube(update):
                     "scheduledStartTime": service_object.datetime.isoformat(),
                     "title": service_object.title_string_with_date,
                     "description": youtube_description,
+                },
+                "status": {
+                    "privacyStatus": service_object.youtube_privacy,
                 },
             }
 
@@ -409,7 +407,7 @@ def sync_with_youtube(update):
                             "description": youtube_description,
                         },
                         "status": {
-                            "privacyStatus": youtube_privacy,
+                            "privacyStatus": service_object.youtube_privacy,
                             "selfDeclaredMadeForKids": False,
                             "embeddable": service_object.youtube_is_embeddable,
                         },

--- a/bin/test
+++ b/bin/test
@@ -447,6 +447,16 @@ class testService(unittest.TestCase):
 
         self.assertFalse(service_public_no.youtube_is_embeddable)
 
+    def test_youtube_privacy(self):
+
+        service_public_yes = serviceFactory({AIRTABLE_MAP["stream_public"]: True})
+
+        service_public_no = serviceFactory({})
+
+        self.assertEqual(service_public_yes.youtube_privacy, "public")
+
+        self.assertEqual(service_public_no.youtube_privacy, "unlisted")
+
 
 class testYoutubePlaylist(unittest.TestCase):
     @patch("youtube.Api")


### PR DESCRIPTION
We previously removed these in favour of declaring them in the Video object. It turns out this breaks the update behaviour, as privacy is required in the status object for a livestream. Put them back.

As part of this, move the generation of the privacy string to the Service object, so we can properly isolate and test it.