### PR TITLE
Add ability to vary the service location

### DIFF
--- a/bin/service/__init__.py
+++ b/bin/service/__init__.py
@@ -14,6 +14,7 @@ AIRTABLE_MAP = {
     "churchsuite_image": "ChurchSuite Image",
     "churchsuite_public_identifier": "ChurchSuite public identifier",
     "datetime": "Date & time",
+    "location": "Location",
     "fee_payable": "Fee payable?",
     "has_oos": "Has order of service?",
     "liturgical_name": "Liturgical name",
@@ -149,6 +150,10 @@ class Service:
         return self.datetime - datetime.timedelta(days=1)
 
     @property
+    def location(self):
+        return self.airtable_fields.get(AIRTABLE_MAP["location"])
+
+    @property
     def technician_name(self):
         if self.technician_field:
             return self.airtable_fields.get(AIRTABLE_MAP["technician"])["name"]
@@ -226,8 +231,14 @@ class Service:
         else:
             liturgical_name_description_string = ""
 
-        return "A {service_description} streamed live from St Mary's Church, Whitkirk{liturgical_string}.".format(
+        if self.location:
+            service_location = self.location
+        else:
+            service_location = "St Mary's Church, Whitkirk"
+
+        return "A {service_description} streamed live from {service_location}{liturgical_string}.".format(
             service_description=self.described_as,
+            service_location=service_location,
             liturgical_string=liturgical_name_description_string,
         )
 

--- a/bin/test
+++ b/bin/test
@@ -42,6 +42,11 @@ class testService(unittest.TestCase):
         service = serviceFactory({})
         self.assertIsNone(service.liturgical_name_field)
 
+    def test_location(self):
+
+        service = serviceFactory({AIRTABLE_MAP["location"]: "Some Place"})
+        self.assertEqual(service.location, "Some Place")
+
     def test_technician_field(self):
 
         service = serviceFactory(
@@ -291,6 +296,13 @@ class testService(unittest.TestCase):
 
         standard_service = serviceFactory({AIRTABLE_MAP["name"]: "Test Service"})
 
+        standard_service_at_location = serviceFactory(
+            {
+                AIRTABLE_MAP["name"]: "Test Service",
+                AIRTABLE_MAP["location"]: "Some Place",
+            }
+        )
+
         sung_eucharist_service = serviceFactory(
             {
                 AIRTABLE_MAP["name"]: "Test Sung Eucharist Service",
@@ -306,9 +318,23 @@ class testService(unittest.TestCase):
             }
         )
 
+        sung_eucharist_with_liturgical_name_at_location_service = serviceFactory(
+            {
+                AIRTABLE_MAP["name"]: "Test Sung Eucharist Service",
+                AIRTABLE_MAP["location"]: "Some Place",
+                AIRTABLE_MAP[
+                    "liturgical_name"
+                ]: "the eleventy-first Sunday after Trinity",
+            }
+        )
+
         self.assertEqual(
             standard_service.description,
             "A service streamed live from St Mary's Church, Whitkirk.",
+        )
+        self.assertEqual(
+            standard_service_at_location.description,
+            "A service streamed live from Some Place.",
         )
         self.assertEqual(
             sung_eucharist_service.description,
@@ -317,6 +343,10 @@ class testService(unittest.TestCase):
         self.assertEqual(
             sung_eucharist_with_liturgical_name_service.description,
             "A sung Eucharist streamed live from St Mary's Church, Whitkirk for the eleventy-first Sunday after Trinity.",
+        )
+        self.assertEqual(
+            sung_eucharist_with_liturgical_name_at_location_service.description,
+            "A sung Eucharist streamed live from Some Place for the eleventy-first Sunday after Trinity.",
         )
 
     @patch(


### PR DESCRIPTION
Not all streaming services are from St Mary's, so the location in the description string can now be overridden.