### PR TITLE
Support multi-line text in YouTube thumbnails

### DIFF
--- a/bin/streaming-utilities
+++ b/bin/streaming-utilities
@@ -39,8 +39,6 @@ import googleapiclient.discovery
 import googleapiclient.errors
 from googleapiclient.http import MediaFileUpload
 
-from PIL import Image, ImageFont, ImageDraw, ImageFilter
-
 import services
 from interfaces.youtube import video_in_playlist
 from interfaces import wordpress, airtable
@@ -270,9 +268,6 @@ def sync_with_youtube(update):
         api_service_name, api_version, credentials=creds
     )
 
-    FONT_LATO_BOLD_LG = ImageFont.truetype("fonts/Lato-Bold.ttf", 56)
-    FONT_LATO_REGULAR_MD = ImageFont.truetype("fonts/Lato-Regular.ttf", 42)
-
     for service_object in services.upcoming_streaming_services():
 
         click.echo(service_object.title_string_with_date)
@@ -382,98 +377,31 @@ def sync_with_youtube(update):
 
                     click.echo("Image has changed, replacing")
 
-                    with Image.open(service_object.service_image) as thumb_image:
+                    service_thumbnail.generate()
 
-                        target_image_dimensions = (1280, 720)
-
-                        thumb_image.thumbnail(target_image_dimensions)
-
-                        sized_image = thumb_image.resize(target_image_dimensions)
-
-                        drawing_corner_offset_x = 30
-                        drawing_corner_offset_y = 90
-
-                        # Create piece of canvas to draw text on and blur
-                        blurred = Image.new("RGBA", sized_image.size)
-                        draw = ImageDraw.Draw(blurred)
-
-                        # Text we want to actually write
-                        main_text = service_object.title_string
-                        aux_text = service_object.datetime.strftime("%-d %B %Y")
-
-                        main_text_draw_coordinates = (
-                            drawing_corner_offset_x,
-                            target_image_dimensions[1] - 10 - drawing_corner_offset_y,
+                    if update:
+                        click.echo("Updating YouTube thumbnail...")
+                        thumb_request = youtube.thumbnails().set(
+                            videoId=response["id"],
+                            media_body=MediaFileUpload(
+                                service_thumbnail.generated_image_path
+                            ),
                         )
-                        aux_text_draw_coordinates = (
-                            drawing_corner_offset_x,
-                            target_image_dimensions[1] - 70 - drawing_corner_offset_y,
+                        thumb_request.execute()
+                        airtable.services_table().update(
+                            service_object.id,
+                            {
+                                services.AIRTABLE_MAP[
+                                    "youtube_image_last_uploaded_name"
+                                ]: service_thumbnail.generated_image_hash,
+                            },
                         )
-
-                        draw.text(
-                            xy=main_text_draw_coordinates,
-                            text=main_text,
-                            fill="#030303",
-                            font=FONT_LATO_BOLD_LG,
-                            anchor="ls",
-                        )
-                        draw.text(
-                            xy=aux_text_draw_coordinates,
-                            text=aux_text,
-                            fill="#030303",
-                            font=FONT_LATO_REGULAR_MD,
-                            anchor="ls",
-                        )
-                        blurred = blurred.filter(ImageFilter.BoxBlur(7))
-
-                        # Paste soft text onto background
-                        sized_image.paste(blurred, blurred)
-
-                        # Draw on sharp text
-                        draw = ImageDraw.Draw(sized_image)
-                        draw.text(
-                            xy=main_text_draw_coordinates,
-                            text=main_text,
-                            fill="#FFF",
-                            font=FONT_LATO_BOLD_LG,
-                            anchor="ls",
-                        )
-                        draw.text(
-                            xy=aux_text_draw_coordinates,
-                            text=aux_text,
-                            fill="#FFF",
-                            font=FONT_LATO_REGULAR_MD,
-                            anchor="ls",
-                        )
-
-                        sized_image.save(
-                            service_thumbnail.generated_image_path,
-                            format="JPEG",
-                        )
-
-                        if update:
-                            click.echo("Updating YouTube thumbnail...")
-                            thumb_request = youtube.thumbnails().set(
-                                videoId=response["id"],
-                                media_body=MediaFileUpload(
-                                    service_thumbnail.generated_image_path
-                                ),
+                    else:
+                        click.echo(
+                            click.style(
+                                "In preview mode, skipping thumbnail", fg="yellow"
                             )
-                            thumb_request.execute()
-                            airtable.services_table().update(
-                                service_object.id,
-                                {
-                                    services.AIRTABLE_MAP[
-                                        "youtube_image_last_uploaded_name"
-                                    ]: service_thumbnail.generated_image_hash,
-                                },
-                            )
-                        else:
-                            click.echo(
-                                click.style(
-                                    "In preview mode, skipping thumbnail", fg="yellow"
-                                )
-                            )
+                        )
 
             # Now, add to playlists!
             for playlist in service_object.youtube_playlists_for_service:

--- a/bin/streaming-utilities
+++ b/bin/streaming-utilities
@@ -21,9 +21,6 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 import requests
 
-import hashlib
-import json
-
 import botocore
 import boto3
 import click
@@ -47,6 +44,7 @@ from PIL import Image, ImageFont, ImageDraw, ImageFilter
 import services
 from interfaces.youtube import video_in_playlist
 from interfaces import wordpress, airtable
+from generators.youtube_thumbnails import YoutubeThumbnail
 
 CHURCHSUITE_ACCOUNT = os.environ["CHURCHSUITE_ACCOUNT"]
 
@@ -279,8 +277,6 @@ def sync_with_youtube(update):
 
         click.echo(service_object.title_string_with_date)
 
-        service_image = service_object.service_image
-
         # Actually build objects and perform updates
 
         # Set the privacy
@@ -375,35 +371,18 @@ def sync_with_youtube(update):
                     )
                 )
 
-            if service_image:
+            if service_object.service_image:
 
-                # Get the resource metadata, so we can compare the filename
+                service_thumbnail = YoutubeThumbnail(service_object)
 
-                yt_thumb_data_hash_dict = {
-                    "title": service_object.title_string,
-                    "datetime": service_object.datetime.strftime("%-d %B %Y"),
-                    "version": 2,
-                }
-
-                yt_thumb_data_hash = hashlib.md5(
-                    json.dumps(yt_thumb_data_hash_dict, sort_keys=True).encode("utf-8")
-                ).hexdigest()
-
-                service_image_with_hash = service_image + "_" + yt_thumb_data_hash
-
-                last_uploaded_file = service_object.youtube_image_last_uploaded_name
-
-                if last_uploaded_file != service_image_with_hash:
+                if (
+                    service_object.youtube_image_last_uploaded_name
+                    != service_thumbnail.generated_image_hash
+                ):
 
                     click.echo("Image has changed, replacing")
 
-                    with Image.open(service_image) as thumb_image:
-
-                        generated_image_path = (
-                            "images/youtube_generated_thumbnails/{hash}.jpg".format(
-                                hash=yt_thumb_data_hash
-                            )
-                        )
+                    with Image.open(service_object.service_image) as thumb_image:
 
                         target_image_dimensions = (1280, 720)
 
@@ -468,7 +447,7 @@ def sync_with_youtube(update):
                         )
 
                         sized_image.save(
-                            generated_image_path,
+                            service_thumbnail.generated_image_path,
                             format="JPEG",
                         )
 
@@ -476,7 +455,9 @@ def sync_with_youtube(update):
                             click.echo("Updating YouTube thumbnail...")
                             thumb_request = youtube.thumbnails().set(
                                 videoId=response["id"],
-                                media_body=MediaFileUpload(generated_image_path),
+                                media_body=MediaFileUpload(
+                                    service_thumbnail.generated_image_path
+                                ),
                             )
                             thumb_request.execute()
                             airtable.services_table().update(
@@ -484,7 +465,7 @@ def sync_with_youtube(update):
                                 {
                                     services.AIRTABLE_MAP[
                                         "youtube_image_last_uploaded_name"
-                                    ]: service_image_with_hash,
+                                    ]: service_thumbnail.generated_image_hash,
                                 },
                             )
                         else:

--- a/generators/youtube_thumbnails.py
+++ b/generators/youtube_thumbnails.py
@@ -8,6 +8,10 @@ FONT_LATO_REGULAR_MD = ImageFont.truetype("fonts/Lato-Regular.ttf", 42)
 
 GENERATOR_VERSION = 3
 
+TARGET_THUMBNAIL_DIMENSIONS = (1280, 720)
+HORIZONTAL_MARGIN = 30
+BOTTOM_MARGIN = 90
+
 
 class YoutubeThumbnail:
     def __init__(self, service):
@@ -42,14 +46,11 @@ class YoutubeThumbnail:
 
         with Image.open(self.service_image_path) as thumb_image:
 
-            target_image_dimensions = (1280, 720)
+            # Thumbnail the image, which handles cropping and resizing down (but not up)
+            thumb_image.thumbnail(TARGET_THUMBNAIL_DIMENSIONS)
 
-            thumb_image.thumbnail(target_image_dimensions)
-
-            sized_image = thumb_image.resize(target_image_dimensions)
-
-            drawing_corner_offset_x = 30
-            drawing_corner_offset_y = 90
+            # Resize the image, which scales it back up if necessary
+            sized_image = thumb_image.resize(TARGET_THUMBNAIL_DIMENSIONS)
 
             # Create piece of canvas to draw text on and blur
             blurred = Image.new("RGBA", sized_image.size)
@@ -60,12 +61,12 @@ class YoutubeThumbnail:
             aux_text = self.service.datetime.strftime("%-d %B %Y")
 
             main_text_draw_coordinates = (
-                drawing_corner_offset_x,
-                target_image_dimensions[1] - 10 - drawing_corner_offset_y,
+                HORIZONTAL_MARGIN,
+                TARGET_THUMBNAIL_DIMENSIONS[1] - 10 - BOTTOM_MARGIN,
             )
             aux_text_draw_coordinates = (
-                drawing_corner_offset_x,
-                target_image_dimensions[1] - 70 - drawing_corner_offset_y,
+                HORIZONTAL_MARGIN,
+                TARGET_THUMBNAIL_DIMENSIONS[1] - 70 - BOTTOM_MARGIN,
             )
 
             draw.text(

--- a/generators/youtube_thumbnails.py
+++ b/generators/youtube_thumbnails.py
@@ -11,6 +11,7 @@ GENERATOR_VERSION = 3
 TARGET_THUMBNAIL_DIMENSIONS = (1280, 720)
 HORIZONTAL_MARGIN = 30
 BOTTOM_MARGIN = 90
+SPACING_BETWEEN_TEXT = 8
 
 
 class YoutubeThumbnail:
@@ -60,13 +61,23 @@ class YoutubeThumbnail:
             main_text = self.service.title_string
             aux_text = self.service.datetime.strftime("%-d %B %Y")
 
+            # Figure out the bounding boxes for our text
+            main_text_bounding = FONT_LATO_BOLD_LG.getbbox(main_text, anchor="ld")
+            main_text_height = -main_text_bounding[1]
+
+            print(main_text_bounding)
+
             main_text_draw_coordinates = (
                 HORIZONTAL_MARGIN,
                 TARGET_THUMBNAIL_DIMENSIONS[1] - 10 - BOTTOM_MARGIN,
             )
+
             aux_text_draw_coordinates = (
                 HORIZONTAL_MARGIN,
-                TARGET_THUMBNAIL_DIMENSIONS[1] - 70 - BOTTOM_MARGIN,
+                TARGET_THUMBNAIL_DIMENSIONS[1]
+                - main_text_height
+                - BOTTOM_MARGIN
+                - SPACING_BETWEEN_TEXT,
             )
 
             draw.text(
@@ -81,7 +92,7 @@ class YoutubeThumbnail:
                 text=aux_text,
                 fill="#030303",
                 font=FONT_LATO_REGULAR_MD,
-                anchor="ls",
+                anchor="ld",
             )
             blurred = blurred.filter(ImageFilter.BoxBlur(7))
 
@@ -102,7 +113,7 @@ class YoutubeThumbnail:
                 text=aux_text,
                 fill="#FFF",
                 font=FONT_LATO_REGULAR_MD,
-                anchor="ls",
+                anchor="ld",
             )
 
             sized_image.save(

--- a/generators/youtube_thumbnails.py
+++ b/generators/youtube_thumbnails.py
@@ -9,7 +9,8 @@ FONT_LATO_REGULAR_MD = ImageFont.truetype("fonts/Lato-Regular.ttf", 42)
 GENERATOR_VERSION = 3
 
 TARGET_THUMBNAIL_DIMENSIONS = (1280, 720)
-HORIZONTAL_MARGIN = 30
+LEFT_MARGIN = 30
+RIGHT_MARGIN = 120
 BOTTOM_MARGIN = 90
 SPACING_BETWEEN_TEXT = 8
 
@@ -61,31 +62,65 @@ class YoutubeThumbnail:
             main_text = self.service.title_string
             aux_text = self.service.datetime.strftime("%-d %B %Y")
 
-            # Figure out the bounding boxes for our text
-            main_text_bounding = FONT_LATO_BOLD_LG.getbbox(main_text, anchor="ld")
-            main_text_height = -main_text_bounding[1]
-
-            print(main_text_bounding)
-
             main_text_draw_coordinates = (
-                HORIZONTAL_MARGIN,
+                LEFT_MARGIN,
                 TARGET_THUMBNAIL_DIMENSIONS[1] - 10 - BOTTOM_MARGIN,
             )
 
-            aux_text_draw_coordinates = (
-                HORIZONTAL_MARGIN,
-                TARGET_THUMBNAIL_DIMENSIONS[1]
-                - main_text_height
-                - BOTTOM_MARGIN
-                - SPACING_BETWEEN_TEXT,
+            # Figure out the bounding boxes for our main text
+            main_text_bounding = draw.textbbox(
+                main_text_draw_coordinates,
+                main_text,
+                anchor="ld",
+                font=FONT_LATO_BOLD_LG,
             )
 
-            draw.text(
+            main_text_max_width = (
+                TARGET_THUMBNAIL_DIMENSIONS[0] - LEFT_MARGIN - RIGHT_MARGIN
+            )
+
+            # Is the text wider than our margins? If not, rock on. If it is, we need to do some wrapping.
+            if main_text_bounding[2] > main_text_max_width:
+                # Start with an empty string
+                main_text_with_breaks = ""
+
+                for word in main_text.split():
+                    # Figure out the size of the box with the new word
+                    text_to_test = main_text_with_breaks + word
+                    main_text_bounding = draw.multiline_textbbox(
+                        main_text_draw_coordinates,
+                        text_to_test,
+                        anchor="ld",
+                        font=FONT_LATO_BOLD_LG,
+                    )
+
+                    if main_text_bounding[2] > main_text_max_width:
+                        # It's too big, throw in a break
+                        main_text_with_breaks += "\n"
+
+                    main_text_with_breaks += word + " "
+
+                # We're done calculating breakpoints, move the broken text to the main variable
+                # and recalculate bounding box
+                main_text = main_text_with_breaks
+                main_text_bounding = draw.multiline_textbbox(
+                    main_text_draw_coordinates,
+                    main_text,
+                    anchor="ld",
+                    font=FONT_LATO_BOLD_LG,
+                )
+
+            aux_text_draw_coordinates = (
+                LEFT_MARGIN,
+                main_text_bounding[1] - SPACING_BETWEEN_TEXT,
+            )
+
+            draw.multiline_text(
                 xy=main_text_draw_coordinates,
                 text=main_text,
                 fill="#030303",
                 font=FONT_LATO_BOLD_LG,
-                anchor="ls",
+                anchor="ld",
             )
             draw.text(
                 xy=aux_text_draw_coordinates,
@@ -106,7 +141,7 @@ class YoutubeThumbnail:
                 text=main_text,
                 fill="#FFF",
                 font=FONT_LATO_BOLD_LG,
-                anchor="ls",
+                anchor="ld",
             )
             draw.text(
                 xy=aux_text_draw_coordinates,

--- a/generators/youtube_thumbnails.py
+++ b/generators/youtube_thumbnails.py
@@ -1,0 +1,35 @@
+import hashlib
+import json
+
+
+GENERATOR_VERSION = 3
+
+
+class YoutubeThumbnail:
+    def __init__(self, service):
+
+        self.service = service
+
+    @property
+    def service_image_name(self):
+        return self.service.service_image
+
+    @property
+    def generated_image_hash(self):
+
+        data_hash_dict = {
+            "image": self.service_image_name,
+            "title": self.service.title_string,
+            "datetime": self.service.datetime.strftime("%-d %B %Y"),
+            "version": GENERATOR_VERSION,
+        }
+
+        return hashlib.md5(
+            json.dumps(data_hash_dict, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+
+    @property
+    def generated_image_path(self):
+        return "images/youtube_generated_thumbnails/{hash}.jpg".format(
+            hash=self.generated_image_hash
+        )

--- a/generators/youtube_thumbnails.py
+++ b/generators/youtube_thumbnails.py
@@ -1,6 +1,10 @@
 import hashlib
 import json
 
+from PIL import Image, ImageFont, ImageDraw, ImageFilter
+
+FONT_LATO_BOLD_LG = ImageFont.truetype("fonts/Lato-Bold.ttf", 56)
+FONT_LATO_REGULAR_MD = ImageFont.truetype("fonts/Lato-Regular.ttf", 42)
 
 GENERATOR_VERSION = 3
 
@@ -11,14 +15,14 @@ class YoutubeThumbnail:
         self.service = service
 
     @property
-    def service_image_name(self):
+    def service_image_path(self):
         return self.service.service_image
 
     @property
     def generated_image_hash(self):
 
         data_hash_dict = {
-            "image": self.service_image_name,
+            "image": self.service_image_path,
             "title": self.service.title_string,
             "datetime": self.service.datetime.strftime("%-d %B %Y"),
             "version": GENERATOR_VERSION,
@@ -33,3 +37,74 @@ class YoutubeThumbnail:
         return "images/youtube_generated_thumbnails/{hash}.jpg".format(
             hash=self.generated_image_hash
         )
+
+    def generate(self):
+
+        with Image.open(self.service_image_path) as thumb_image:
+
+            target_image_dimensions = (1280, 720)
+
+            thumb_image.thumbnail(target_image_dimensions)
+
+            sized_image = thumb_image.resize(target_image_dimensions)
+
+            drawing_corner_offset_x = 30
+            drawing_corner_offset_y = 90
+
+            # Create piece of canvas to draw text on and blur
+            blurred = Image.new("RGBA", sized_image.size)
+            draw = ImageDraw.Draw(blurred)
+
+            # Text we want to actually write
+            main_text = self.service.title_string
+            aux_text = self.service.datetime.strftime("%-d %B %Y")
+
+            main_text_draw_coordinates = (
+                drawing_corner_offset_x,
+                target_image_dimensions[1] - 10 - drawing_corner_offset_y,
+            )
+            aux_text_draw_coordinates = (
+                drawing_corner_offset_x,
+                target_image_dimensions[1] - 70 - drawing_corner_offset_y,
+            )
+
+            draw.text(
+                xy=main_text_draw_coordinates,
+                text=main_text,
+                fill="#030303",
+                font=FONT_LATO_BOLD_LG,
+                anchor="ls",
+            )
+            draw.text(
+                xy=aux_text_draw_coordinates,
+                text=aux_text,
+                fill="#030303",
+                font=FONT_LATO_REGULAR_MD,
+                anchor="ls",
+            )
+            blurred = blurred.filter(ImageFilter.BoxBlur(7))
+
+            # Paste soft text onto background
+            sized_image.paste(blurred, blurred)
+
+            # Draw on sharp text
+            draw = ImageDraw.Draw(sized_image)
+            draw.text(
+                xy=main_text_draw_coordinates,
+                text=main_text,
+                fill="#FFF",
+                font=FONT_LATO_BOLD_LG,
+                anchor="ls",
+            )
+            draw.text(
+                xy=aux_text_draw_coordinates,
+                text=aux_text,
+                fill="#FFF",
+                font=FONT_LATO_REGULAR_MD,
+                anchor="ls",
+            )
+
+            sized_image.save(
+                self.generated_image_path,
+                format="JPEG",
+            )

--- a/tests/test_generators_youtube_thumb.py
+++ b/tests/test_generators_youtube_thumb.py
@@ -1,0 +1,100 @@
+import os
+
+from unittest.mock import patch
+
+from services import AIRTABLE_MAP, Service
+
+from generators.youtube_thumbnails import YoutubeThumbnail
+
+
+def serviceFactory(fields, id="a1b2c3d4"):
+
+    return Service({"id": id, "fields": fields})
+
+
+def test_service_image_path():
+    service = serviceFactory({})
+    youtube_thumbnail = YoutubeThumbnail(service)
+
+    assert (
+        youtube_thumbnail.service_image_path == "images/default_thumbnails/service.jpg"
+    )
+
+
+@patch(
+    "generators.youtube_thumbnails.GENERATOR_VERSION",
+    1,
+)
+def test_generated_image_hash():
+    service = serviceFactory(
+        {
+            AIRTABLE_MAP["name"]: "Test Service",
+            AIRTABLE_MAP["datetime"]: "2022-01-01T10:00:00.000Z",
+        }
+    )
+    youtube_thumbnail = YoutubeThumbnail(service)
+
+    assert youtube_thumbnail.generated_image_hash == "98e95ba1746fb2c670edbb639d50c585"
+
+
+@patch(
+    "generators.youtube_thumbnails.GENERATOR_VERSION",
+    1,
+)
+def test_generated_image_path():
+    service = serviceFactory(
+        {
+            AIRTABLE_MAP["name"]: "Test Service",
+            AIRTABLE_MAP["datetime"]: "2022-01-01T10:00:00.000Z",
+        }
+    )
+    youtube_thumbnail = YoutubeThumbnail(service)
+
+    assert (
+        youtube_thumbnail.generated_image_path
+        == "images/youtube_generated_thumbnails/98e95ba1746fb2c670edbb639d50c585.jpg"
+    )
+
+
+@patch(
+    "generators.youtube_thumbnails.GENERATOR_VERSION",
+    1,
+)
+def test_generate_saves_image_with_single_line_title():
+
+    service = serviceFactory(
+        {
+            AIRTABLE_MAP["name"]: "Test Service",
+            AIRTABLE_MAP["datetime"]: "2022-01-01T10:00:00.000Z",
+        }
+    )
+    youtube_thumbnail = YoutubeThumbnail(service)
+
+    youtube_thumbnail.generate()
+
+    assert os.path.isfile(
+        "images/youtube_generated_thumbnails/98e95ba1746fb2c670edbb639d50c585.jpg"
+    )
+
+
+@patch(
+    "generators.youtube_thumbnails.GENERATOR_VERSION",
+    1,
+)
+def test_generate_saves_image_with_multi_line_title():
+
+    service = serviceFactory(
+        {
+            AIRTABLE_MAP[
+                "name"
+            ]: "Test Service with an unusually long title designed to test multi-line behaviour",
+            AIRTABLE_MAP["datetime"]: "2022-01-01T10:00:00.000Z",
+        }
+    )
+    youtube_thumbnail = YoutubeThumbnail(service)
+
+    youtube_thumbnail.generate()
+
+    assert os.path.isfile(
+        "images/youtube_generated_thumbnails/c55ed34a5c26be1fa6723d7afdb1a036.jpg"
+    )


### PR DESCRIPTION
Some services, particularly one-offs, have titles which are too long for a single line in the thumbnail generator.

Dynamically calculate where to place line breaks if this is the case, and adjust positioning for aux text accordingly.